### PR TITLE
HTTP Error 999 (returned by LinkedIn) is not a bad page

### DIFF
--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -52,6 +52,8 @@ class HtmlProoferPlugin(BasePlugin):
             return False
         elif url_status == 503:
             return False
+        elif url_status == 999:
+            return False
         elif url_status >= 400:
             return True
         return False

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -53,6 +53,7 @@ class HtmlProoferPlugin(BasePlugin):
         elif url_status == 503:
             return False
         elif url_status == 999:
+            # Returned by some websites (e.g. LinkedIn) that think you're crawling them.
             return False
         elif url_status >= 400:
             return True


### PR DESCRIPTION
I noticed when checking links to webpages on LinkedIn.com with this plugin that LinkedIn's web server replies with an (unofficial) HTTP 999 error because it thinks I'm crawling their web site.

For checking links this is probably almost always a false positive, so in this PR I handle them like HTTP 401 or 403: return `False` in `bad_url`.