### PR TITLE
Add support for Python 3.8-3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 0. Prerequisites
 
-* Python >= 3.5
+* Python >= 3.6
 * MkDocs >= 0.17
 
 1. Install the package with pip:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author='Manu Zhang',
     author_email='owenzhang1990@gmail.com',
     license='MIT',
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     install_requires=[
         'mkdocs>=0.17',
         'requests',
@@ -30,9 +30,10 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     packages=find_packages(exclude=['*.tests']),
     entry_points={


### PR DESCRIPTION
- Add support for Python 3.8-3.9
- Drop support for [end-of-life Python 3.5](https://www.python.org/dev/peps/pep-0478/#release-schedule)
- Enable CI on Pull Requests