### PR TITLE
Ignore HTTPS localhost URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ venv.bak/
 
 # Tests
 test/site
+
+# PyCharm
+.idea

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -42,7 +42,7 @@ class HtmlProoferPlugin(BasePlugin):
     @lru_cache(maxsize=500)
     def get_url_status(self, url, soup):
         for local in ('localhost', '127.0.0.1', 'app_server'):
-            if url.startswith('http://' + local):
+            if re.match(f'https?://{local}', url):
                 return (url, 0)
         clean_url = url.strip('?.')
         if url.startswith('#') and not soup.find(id=url.strip('#')):

--- a/test/docs/index.md
+++ b/test/docs/index.md
@@ -53,7 +53,18 @@ plugins:
 
 More information about plugins in the [MkDocs documentation](http://www.mkdocs.org/user-guide/plugin)
 
+## `localhost` URLs
+
+`localhost` URLs are safely ignored by `mkdocs-htmlproofer-plugin` and will not raise warnings:
+
+- <http://localhost>
+
+- <http://127.0.0.1>
+
+- <https://localhost>
+
+- <https://127.0.0.1>
+
 ## Acknowledgement
 
 This work is based on the [mkdocs-markdownextradata-plugin](https://github.com/rosscdh/mkdocs-markdownextradata-plugin) project and the [Finding and Fixing Website Link Rot with Python, BeautifulSoup and Requests](https://www.twilio.com/blog/2018/07/find-fix-website-link-rot-python-beautifulsoup-requests.html) article. 
-

--- a/test/mkdocs.yml
+++ b/test/mkdocs.yml
@@ -1,5 +1,7 @@
+strict: True
 site_name: Test mkdocs-htmlproofer-plugin
-
+site_url: ''
+use_directory_urls: False
 plugins:
     - htmlproofer:
         raise_error: True


### PR DESCRIPTION
Closes #17 

Also:

- Enable `strict` MkDocs configuration in testing to catch any MkDocs warnings in CI
- Fix support of [MkDocs 1.2](https://www.mkdocs.org/about/release-notes/#backward-incompatible-changes-in-12) in test project by added a blank `site_url`