### PR TITLE
Use HTTPS for 404 test URL

### DIFF
--- a/test/docs/index.md
+++ b/test/docs/index.md
@@ -51,7 +51,7 @@ plugins:
 
 > **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
 
-More information about plugins in the [MkDocs documentation](http://www.mkdocs.org/user-guide/plugin)
+More information about plugins in the [MkDocs documentation](https://www.mkdocs.org/user-guide/plugin)
 
 ## `localhost` URLs
 

--- a/test/mkdocs.yml
+++ b/test/mkdocs.yml
@@ -7,4 +7,4 @@ plugins:
         raise_error: True
         raise_error_excludes:
           504: ['*']
-          404: ['http://www.mkdocs.org/user-guide/plugin', '#acknowledge'] 
+          404: ['https://www.mkdocs.org/user-guide/plugin', '#acknowledge']


### PR DESCRIPTION
This makes the test project slightly more secure by not using HTTP URLs.