### PR TITLE
Improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,37 @@ plugins:
     - htmlproofer
 ```
 
-Optionally, you may raise error and fail the build on bad url status.
+> **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin.
+MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
 
 ```yaml
 plugins:
     - search
+    - htmlproofer
+```
+
+To enable cross-page anchor validation, you must set `use_directory_urls = False` in `mkdocs.yml`:
+
+```yaml
+use_directory_urls: False
+```
+
+## Configuring
+
+### `raise_error`
+
+Optionally, you may raise an error and fail the build on bad url status.
+
+```yaml
+plugins:
     - htmlproofer:
         raise_error: True
 ```
 
-That can be switched off for combinations of urls (`'*'` means all urls) and status codes with `raise_error_excludes`.
+### `raise_error_excludes`
+
+When specifying `raise_error: True`, it is possible to ignore errors
+for combinations of urls (`'*'` means all urls) and status codes with `raise_error_excludes`.
 
 ```yaml
 plugins:
@@ -47,13 +68,13 @@ plugins:
           400: ['*']
 ```
 
-> **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin. MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
+## Performance
 
-To enable cross-page anchor validation, you must set `use_directory_urls = False` in `mkdocs.yml`:
+[BeautifulSoup](https://beautiful-soup-4.readthedocs.io/en/latest/) is used to parse HTML as part of
+validation. When `lxml` and `cchardet` are installed in the Python environment, a faster parser will
+be used automatically.
 
-```yaml
-use_directory_urls: False
-```
+## Improving
 
 More information about plugins in the [MkDocs documentation](http://www.mkdocs.org/user-guide/plugins/)
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,6 @@ plugins:
           400: ['*']
 ```
 
-## Performance
-
-[BeautifulSoup](https://beautiful-soup-4.readthedocs.io/en/latest/) is used to parse HTML as part of
-validation. When `lxml` and `cchardet` are installed in the Python environment, a faster parser will
-be used automatically.
-
 ## Improving
 
 More information about plugins in the [MkDocs documentation](http://www.mkdocs.org/user-guide/plugins/)

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -159,7 +159,7 @@ class HtmlProoferPlugin(BasePlugin):
         elif url_status == 401 or url_status == 403:
             return False
         elif url_status in (503, 504):
-          # Usually transient
+            # Usually transient
             return False
         elif url_status == 999:
             # Returned by some websites (e.g. LinkedIn) that think you're crawling them.

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -1,10 +1,10 @@
 from functools import lru_cache
 import re
 import sys
-from typing import Optional, Tuple
+from typing import Optional, Set, Tuple
 import uuid
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, SoupStrainer
 from markdown.extensions.toc import slugify
 from mkdocs.config import Config, config_options
 from mkdocs.exceptions import PluginError
@@ -14,9 +14,24 @@ from mkdocs.structure.pages import Page
 import requests
 import urllib3
 
+try:
+    import lxml
+    LXML_AVAILABLE = True
+except ImportError:
+    LXML_AVAILABLE = False
+
 URL_TIMEOUT = 10.0
 _URL_BOT_ID = f'Bot {uuid.uuid4()}'
 URL_HEADERS = {'User-Agent': _URL_BOT_ID}
+
+EXTERNAL_URL_PATTERN = re.compile(r'https?://')
+MARKDOWN_ANCHOR_PATTERN = re.compile(r'(.+)#(.+)')
+HEADING_PATTERN = re.compile(r'\s*#+\s*(.*)')
+HTML_LINK_PATTERN = re.compile(r'.*<a id=\"(.*)\">.*')
+LOCAL_PATTERNS = (
+    re.compile(rf'https?://{local}')
+    for local in ('localhost', '127.0.0.1', 'app_server')
+)
 
 urllib3.disable_warnings()
 
@@ -26,56 +41,76 @@ class HtmlProoferPlugin(BasePlugin):
 
     config_scheme = (
         ('raise_error', config_options.Type(bool, default=False)),
-        ('raise_error_excludes', config_options.Type(dict, default={}))
+        ('raise_error_excludes', config_options.Type(dict, default={})),
     )
-
-    def on_page_markdown(self, markdown: str, page: Page, config: Config, files: Files) -> None:
-        # Store files to allow inspecting Markdown files in later stages.
-        self.files = files
 
     def on_post_page(self, output_content: str, page: Page, config: Config) -> None:
         use_directory_urls = config.data["use_directory_urls"]
-        soup = BeautifulSoup(output_content, 'html.parser')
+
+        # Optimization: use lxml as the parser if available
+        soup_parser = 'lxml' if LXML_AVAILABLE else 'html.parser'
+
+        # Optimization: only parse links and headings
+        # li, sup are used for footnotes
+        strainer = SoupStrainer(('a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'sup'))
+
+        soup = BeautifulSoup(output_content, soup_parser, parse_only=strainer)
+
+        all_element_ids = set(tag['id'] for tag in soup.select('[id]'))
         for a in soup.find_all('a', href=True):
             url = a['href']
-            clean_url, url_status = self.get_url_status(url, soup, self.files, use_directory_urls)
+
+            clean_url, url_status = self.get_url_status(url, all_element_ids, self.files, use_directory_urls)
+
             if self.bad_url(url_status) is True:
-                error = f'{clean_url}: {url_status}'
-                excludes = self.config['raise_error_excludes']
-                if (self.config['raise_error'] and
-                        (url_status not in excludes or
-                         ('*' not in excludes[url_status] and
-                          url not in excludes[url_status]))):
+                error = f'invalid url - {clean_url} [{url_status}] [{page.file.src_path}]'
+
+                is_error = self.is_error(self.config, url, url_status)
+                if self.config['raise_error'] and is_error:
                     raise PluginError(error)
-                else:
+                elif is_error:
                     print(error)
 
-    @lru_cache(maxsize=500)
-    def get_url_status(self, url: str, soup: BeautifulSoup, files: Files,
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _session():
+        session = requests.Session()
+        session.verify = False
+        session.headers.update(URL_HEADERS)
+        session.max_redirects = 5
+        return session
+
+    @classmethod
+    @lru_cache(maxsize=1000)
+    def get_external_url(cls, url: str) -> int:
+        try:
+            response = cls._session().head(url, timeout=URL_TIMEOUT)
+            return response.status_code
+        except requests.exceptions.Timeout:
+            return 504
+        except requests.exceptions.TooManyRedirects:
+            return -1
+        except requests.exceptions.ConnectionError:
+            return -1
+
+    def get_url_status(self, url: str, all_element_ids: Set[str], files: Files,
                        use_directory_urls: bool) -> Tuple[str, int]:
-        for local in ('localhost', '127.0.0.1', 'app_server'):
-            if re.match(rf'https?://{local}', url):
-                return url, 0
+        if any(pat.match(url) for pat in LOCAL_PATTERNS):
+            return url, 0
         clean_url = url.strip('?.')
-        if url.startswith('#') and not soup.find(id=url.strip('#')):
+
+        if url.startswith('#') and not url.lstrip('#') in all_element_ids:
             return url, 404
-        elif re.match(r'https?://', clean_url):
-            try:
-                response = requests.get(
-                    clean_url, verify=False, timeout=URL_TIMEOUT,
-                    headers=URL_HEADERS)
-                return clean_url, response.status_code
-            except requests.exceptions.Timeout:
-                return clean_url, 504
-            except requests.exceptions.ConnectionError:
-                return clean_url, -1
-        else:
-            match = re.match(r'(.+)#(.+)', clean_url)
+        elif EXTERNAL_URL_PATTERN.match(clean_url):
+            return url, self.get_external_url(clean_url)
+        elif not use_directory_urls:
             # use_directory_urls = True injects too many challenges for locating the correct target
             # Markdown file, so disable target anchor validation in this case. Examples include:
             # ../..#BAD_ANCHOR style links to index.html and extra ../ inserted into relative
             # links.
-            if match is not None and not use_directory_urls:
+
+            match = MARKDOWN_ANCHOR_PATTERN.match(clean_url)
+            if match is not None:
                 # URL is a link to another local Markdown file that includes an anchor.
                 url_target, anchor = match.groups()
                 target_markdown = self.find_target_markdown(url_target, files)
@@ -83,8 +118,7 @@ class HtmlProoferPlugin(BasePlugin):
                         or not self.contains_anchor(target_markdown, anchor)):
                     # The corresponding Markdown header for this anchor was not found.
                     return url, 404
-
-            return url, 0
+        return url, 0
 
     @staticmethod
     def find_target_markdown(url: str, files: Files) -> Optional[str]:
@@ -109,9 +143,9 @@ class HtmlProoferPlugin(BasePlugin):
         given anchor."""
         for line in markdown.splitlines():
             # Markdown allows whitespace before headers and an arbitrary number of #'s.
-            match = re.match(rf'\s*#+\s*(.*)', line)
-            if match is not None:
-                heading = match.groups()[0]
+            heading_match = HEADING_PATTERN.match(line)
+            if heading_match is not None:
+                heading = heading_match.groups()[0]
 
                 # Headings are allowed to have images after them, of the form:
                 # # Heading [![Image][image-link]]
@@ -120,6 +154,11 @@ class HtmlProoferPlugin(BasePlugin):
                 anchor_slug = slugify(heading, '-')
                 if anchor == anchor_slug:
                     return True
+
+            link_match = HTML_LINK_PATTERN.match(line)
+            if link_match is not None and link_match.group(1) == anchor:
+                return True
+
         return False
 
     @staticmethod
@@ -128,7 +167,8 @@ class HtmlProoferPlugin(BasePlugin):
             return True
         elif url_status == 401 or url_status == 403:
             return False
-        elif url_status == 503:
+        elif url_status in (503, 504):
+          # Usually transient
             return False
         elif url_status == 999:
             # Returned by some websites (e.g. LinkedIn) that think you're crawling them.
@@ -136,3 +176,12 @@ class HtmlProoferPlugin(BasePlugin):
         elif url_status >= 400:
             return True
         return False
+
+    @staticmethod
+    def is_error(config: Config, url: str, url_status: int) -> bool:
+        excludes = config['raise_error_excludes'].get(url_status, [])
+
+        if '*' in excludes or url in excludes:
+            return False
+
+        return True

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -22,10 +22,10 @@ EXTERNAL_URL_PATTERN = re.compile(r'https?://')
 MARKDOWN_ANCHOR_PATTERN = re.compile(r'(.+)#(.+)')
 HEADING_PATTERN = re.compile(r'\s*#+\s*(.*)')
 HTML_LINK_PATTERN = re.compile(r'.*<a id=\"(.*)\">.*')
-LOCAL_PATTERNS = (
+LOCAL_PATTERNS = [
     re.compile(rf'https?://{local}')
     for local in ('localhost', '127.0.0.1', 'app_server')
-)
+]
 
 urllib3.disable_warnings()
 
@@ -59,7 +59,7 @@ class HtmlProoferPlugin(BasePlugin):
         soup = BeautifulSoup(output_content, 'lxml', parse_only=strainer)
 
         all_element_ids = set(tag['id'] for tag in soup.select('[id]'))
-        all_element_ids.add('#')  # Empty anchor is commonly used, but not real
+        all_element_ids.add('')  # Empty anchor is commonly used, but not real
         for a in soup.find_all('a', href=True):
             url = a['href']
 

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -14,12 +14,6 @@ from mkdocs.structure.pages import Page
 import requests
 import urllib3
 
-try:
-    import lxml
-    LXML_AVAILABLE = True
-except ImportError:
-    LXML_AVAILABLE = False
-
 URL_TIMEOUT = 10.0
 _URL_BOT_ID = f'Bot {uuid.uuid4()}'
 URL_HEADERS = {'User-Agent': _URL_BOT_ID}
@@ -47,14 +41,11 @@ class HtmlProoferPlugin(BasePlugin):
     def on_post_page(self, output_content: str, page: Page, config: Config) -> None:
         use_directory_urls = config.data["use_directory_urls"]
 
-        # Optimization: use lxml as the parser if available
-        soup_parser = 'lxml' if LXML_AVAILABLE else 'html.parser'
-
         # Optimization: only parse links and headings
         # li, sup are used for footnotes
         strainer = SoupStrainer(('a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'sup'))
 
-        soup = BeautifulSoup(output_content, soup_parser, parse_only=strainer)
+        soup = BeautifulSoup(output_content, 'lxml', parse_only=strainer)
 
         all_element_ids = set(tag['id'] for tag in soup.select('[id]'))
         for a in soup.find_all('a', href=True):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         'mkdocs>=0.17',
         'Markdown',
         'requests',
-        'beautifulsoup4'
+        'beautifulsoup4',
+        'lxml',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This introduces a number of performance improvements to help make this plugin feasible for larger documentation sets.

Performance:

 * Use the faster `lxml` parser for BeautifulSoup
 * Use a `SoupStrainer` to only consider elements that should represent links  
 * Compile regular expressions once and store on the module, rather than re-compiling repeatedly
 * Move `lru_cache` to a dedicated staticmethod to fetch external URLs. This allows external URLs to be cached between pages. Note that serializing the `BeautifulSoup` arg for use with the cache was very expensive before, so this also avoids that.
 * Use a `requests.Session` for HTTP requests
 * Make `HEAD` requests instead of `GET`. Note that some sites may not handle this correctly, but generally this seemed to work fine 

Features:

 * Adds support for `<a id="blah"></a>` links in markdown pages, where people may want to support custom links in addition to the slugified headings.

Other:

 * Only prints errors to stdout when `raise_error_excludes` does not match. This reduces unnecessary noise
 * Changes the output format for errors to `invalid url - {clean_url} [{url_status}] [{page.file.src_path}]` to provide more information