### PR TITLE
Add validate_external_urls config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,21 @@ plugins:
     - search
     - htmlproofer:
         raise_error: True
-        raise_error_excludes: 
+        raise_error_excludes:
           504: ['https://www.mkdocs.org/']
           404: ['https://github.com/manuzhang/mkdocs-htmlproofer-plugin']
           400: ['*']
+```
+
+### `validate_external_urls`
+
+Avoids validating any external URLs (i.e those starting with http:// or https://).
+This will be faster if you just want to validate local anchors, as it does not make any network requests.
+
+```
+plugins:
+  - htmlproofer:
+      validate_external_urls: False
 ```
 
 ## Improving

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -38,6 +38,7 @@ class HtmlProoferPlugin(BasePlugin):
     config_scheme = (
         ('raise_error', config_options.Type(bool, default=False)),
         ('raise_error_excludes', config_options.Type(dict, default={})),
+        ('validate_external_urls', config_options.Type(bool, default=True)),
     )
 
     def __init__(self):
@@ -96,6 +97,8 @@ class HtmlProoferPlugin(BasePlugin):
         if url.startswith('#'):
             return 0 if url[1:] in all_element_ids else 404
         elif EXTERNAL_URL_PATTERN.match(url):
+            if not self.config['validate_external_urls']:
+                return 0
             return self.get_external_url(url)
         elif not use_directory_urls:
             # use_directory_urls = True injects too many challenges for locating the correct target

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -9,7 +9,9 @@ from htmlproofer.plugin import HtmlProoferPlugin
 
 @pytest.fixture
 def plugin():
-    return HtmlProoferPlugin()
+    plugin = HtmlProoferPlugin()
+    plugin.load_config({})
+    return plugin
 
 
 @pytest.fixture
@@ -36,8 +38,21 @@ def test_get_url_status__ignore_local_servers(plugin, empty_files, url):
     assert plugin.get_url_status(url, 'src/path.md', set(), empty_files, False) == 0
 
 
-def test_get_url_status__dont_validate_external(plugin):
-    assert plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False) == 0
+
+@pytest.mark.parametrize(
+    'validate_external', (True, False)
+)
+def test_get_url_status(validate_external: bool):
+    plugin = HtmlProoferPlugin()
+    plugin.load_config({'validate_external_urls': validate_external})
+
+    get_url = lambda: plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
+
+    if validate_external:
+        with pytest.raises(Exception):
+            get_url()
+    else:
+        assert get_url() == 0
 
 
 def test_get_url_status__same_page_anchor(plugin, empty_files):

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -36,6 +36,10 @@ def test_get_url_status__ignore_local_servers(plugin, empty_files, url):
     assert plugin.get_url_status(url, 'src/path.md', set(), empty_files, False) == 0
 
 
+def test_get_url_status__dont_validate_external(plugin):
+    assert plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False) == 0
+
+
 def test_get_url_status__same_page_anchor(plugin, empty_files):
     assert plugin.get_url_status('#ref', 'src/path.md', {'ref'}, empty_files, False) == 0
     assert plugin.get_url_status('##ref', 'src/path.md', {'ref'}, empty_files, False) == 404


### PR DESCRIPTION
Adds a new option to avoid validating external URLs. For my use case, most external URLs are behind authentication or just cause the plugin execution time to be too long.