### PR TITLE
Add `enabled` and `validate_rendered_template` flags for performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,26 @@ use_directory_urls: False
 
 ## Configuring
 
+### `enabled`
+
+True by default, allows toggling whether the plugin is enabled.
+Useful for local development where you may want faster build times.
+
+```yaml
+# mkdocs.yml
+plugins:
+  - htmlproofer:
+      enabled: !ENV [ENABLED_HTMLPROOFER, True]
+```
+
+Which enables you do disable the plugin locally using:
+
+```bash
+export ENABLED_HTMLPROOFER=false
+mkdocs serve
+```
+
+
 ### `raise_error`
 
 Optionally, you may raise an error and fail the build on bad url status.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ True by default, allows toggling whether the plugin is enabled.
 Useful for local development where you may want faster build times.
 
 ```yaml
-# mkdocs.yml
 plugins:
   - htmlproofer:
       enabled: !ENV [ENABLED_HTMLPROOFER, True]
@@ -68,8 +67,8 @@ Optionally, you may raise an error and fail the build on bad url status.
 
 ```yaml
 plugins:
-    - htmlproofer:
-        raise_error: True
+  - htmlproofer:
+      raise_error: True
 ```
 
 ### `raise_error_excludes`
@@ -79,13 +78,13 @@ for combinations of urls (`'*'` means all urls) and status codes with `raise_err
 
 ```yaml
 plugins:
-    - search
-    - htmlproofer:
-        raise_error: True
-        raise_error_excludes:
-          504: ['https://www.mkdocs.org/']
-          404: ['https://github.com/manuzhang/mkdocs-htmlproofer-plugin']
-          400: ['*']
+  - search
+  - htmlproofer:
+      raise_error: True
+      raise_error_excludes:
+        504: ['https://www.mkdocs.org/']
+        404: ['https://github.com/manuzhang/mkdocs-htmlproofer-plugin']
+        400: ['*']
 ```
 
 ### `validate_external_urls`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ plugins:
       validate_external_urls: False
 ```
 
+### `validate_rendered_template`
+
+Validates the entire rendered template for each page - including the navigation, header, footer, etc.
+This defaults to off because it is much slower and often redundant to repeat for every single page.
+
+```
+plugins:
+  - htmlproofer:
+      validate_rendered_template: True
+```
+
 ## Improving
 
 More information about plugins in the [MkDocs documentation](http://www.mkdocs.org/user-guide/plugins/)

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -36,6 +36,7 @@ class HtmlProoferPlugin(BasePlugin):
     files: Files = None
 
     config_scheme = (
+        ("enabled", config_options.Type(bool, default=True)),
         ('raise_error', config_options.Type(bool, default=False)),
         ('raise_error_excludes', config_options.Type(dict, default={})),
         ('validate_external_urls', config_options.Type(bool, default=True)),
@@ -54,6 +55,9 @@ class HtmlProoferPlugin(BasePlugin):
         self.files = files
 
     def on_post_page(self, output_content: str, page: Page, config: Config) -> None:
+        if not self.config['enabled']:
+            return
+
         use_directory_urls = config.data["use_directory_urls"]
 
         # Optimization: only parse links and headings

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -39,6 +39,7 @@ class HtmlProoferPlugin(BasePlugin):
         ('raise_error', config_options.Type(bool, default=False)),
         ('raise_error_excludes', config_options.Type(dict, default={})),
         ('validate_external_urls', config_options.Type(bool, default=True)),
+        ('validate_rendered_template', config_options.Type(bool, default=False)),
     )
 
     def __init__(self):
@@ -59,7 +60,8 @@ class HtmlProoferPlugin(BasePlugin):
         # li, sup are used for footnotes
         strainer = SoupStrainer(('a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'sup'))
 
-        soup = BeautifulSoup(page.content, 'lxml', parse_only=strainer)
+        content = output_content if self.config['validate_rendered_template'] else page.content
+        soup = BeautifulSoup(content, 'lxml', parse_only=strainer)
 
         all_element_ids = set(tag['id'] for tag in soup.select('[id]'))
         all_element_ids.add('')  # Empty anchor is commonly used, but not real

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -59,7 +59,7 @@ class HtmlProoferPlugin(BasePlugin):
         # li, sup are used for footnotes
         strainer = SoupStrainer(('a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'sup'))
 
-        soup = BeautifulSoup(output_content, 'lxml', parse_only=strainer)
+        soup = BeautifulSoup(page.content, 'lxml', parse_only=strainer)
 
         all_element_ids = set(tag['id'] for tag in soup.select('[id]'))
         all_element_ids.add('')  # Empty anchor is commonly used, but not real

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -55,6 +55,15 @@ def test_on_post_page(empty_files, mock_requests, validate_rendered_template):
         plugin.on_post_page(link_to_500 if validate_rendered_template else '', page, config)
 
 
+def test_on_post_page__plugin_disabled():
+    plugin = HtmlProoferPlugin()
+    plugin.load_config({
+        'enabled': False,
+        'raise_error': True,
+    })
+    plugin.on_post_page('<a href="https://google.com"><a/>', Mock(spec=Page), Mock(spec=Config))
+
+
 @pytest.mark.parametrize(
     'url',
     (

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,7 +1,10 @@
 from unittest.mock import Mock, patch
 
+from mkdocs.config import Config
+from mkdocs.exceptions import PluginError
 from mkdocs.structure.files import File, Files
 from mkdocs.structure.pages import Page
+from requests import Response
 import pytest
 
 from htmlproofer.plugin import HtmlProoferPlugin
@@ -23,7 +26,33 @@ def empty_files():
 def mock_requests():
     with patch('requests.Session.head') as mock_head:
         mock_head.side_effect = Exception("don't make network requests from tests")
-        yield
+        yield mock_head
+
+
+@pytest.mark.parametrize(
+    'validate_rendered_template', (False, True)
+)
+def test_on_post_page(empty_files, mock_requests, validate_rendered_template):
+    plugin = HtmlProoferPlugin()
+    plugin.load_config({
+        'validate_rendered_template': validate_rendered_template,
+        'raise_error': True,
+    })
+
+    # Always raise a 500 error
+    mock_requests.side_effect = [Mock(spec=Response, status_code=500)]
+    link_to_500 = '<a href="https://google.com"><a/>'
+
+    plugin.files = empty_files
+    page = Mock(
+        spec=Page,
+        file=Mock(spec=File, src_path='blah.md'),
+        content='' if validate_rendered_template else link_to_500
+    )
+    config = Mock(spec=Config, data={'use_directory_urls': False})
+
+    with pytest.raises(PluginError):
+        plugin.on_post_page(link_to_500 if validate_rendered_template else '', page, config)
 
 
 @pytest.mark.parametrize(
@@ -36,7 +65,6 @@ def mock_requests():
 )
 def test_get_url_status__ignore_local_servers(plugin, empty_files, url):
     assert plugin.get_url_status(url, 'src/path.md', set(), empty_files, False) == 0
-
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -4,8 +4,8 @@ from mkdocs.config import Config
 from mkdocs.exceptions import PluginError
 from mkdocs.structure.files import File, Files
 from mkdocs.structure.pages import Page
-from requests import Response
 import pytest
+from requests import Response
 
 from htmlproofer.plugin import HtmlProoferPlugin
 


### PR DESCRIPTION
This was roughly a 2x speedup for my use case. It only validates the HTML generated for a specific page, ignoring that added by templates (header, nav, footer, etc.).

I think the existing integration tests should serve as a reasonable test.