### PR TITLE
Remove duplicated code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ pip install mkdocs-htmlproofer-plugin
 
 2. Enable the plugin in your `mkdocs.yml`:
 
-```yaml
-plugins:
-    - search
-    - htmlproofer
-```
-
 > **Note:** If you have no `plugins` entry in your config file yet, you'll likely also want to add the `search` plugin.
 MkDocs enables it by default if there is no `plugins` entry set, but now you have to enable it explicitly.
 


### PR DESCRIPTION
This exact code block is show below the **Note**, so remove it to make the README flow nicer.