### PR TITLE
Compare normalized paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - os: "ubuntu-20.04"

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -129,9 +129,9 @@ class HtmlProoferPlugin(BasePlugin):
         """From a built URL, find the original Markdown source from the project that built it."""
 
         # Handle relative links by concatenating the source dir with the destination path
-        search = os.path.normpath(str(pathlib.Path(src_path).parent / pathlib.Path(url)))
+        search_path = os.path.normpath(str(pathlib.Path(src_path).parent / pathlib.Path(url)))
         for file in files.src_paths.values():  # type: File
-            if file.url == search and file.page:
+            if os.path.normpath(file.url) == search_path and file.page:
                 return file.page.markdown
 
         print(f"Warning: Unable to locate Markdown source file for: {url}", file=sys.stderr)


### PR DESCRIPTION
I noticed the code does not work correctly on windows platform. The root-cause is `os.path.normpath`. `os.path.normpath` modifies path platform-dependent. On a windows-platform, the forward slashes will be replaced by backslashes. The URL should be normalized as well to be consistent.

This is not the nicest solution but it is rather simple.