### PR TITLE
Add option to print all invalid links before raising error

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mkdocs serve
 
 ### `raise_error`
 
-Optionally, you may raise an error and fail the build on first bad url status.
+Optionally, you may raise an error and fail the build on first bad url status. Takes precedense over `raise_error_after_finish`.
 
 ```yaml
 plugins:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ mkdocs serve
 
 ### `raise_error`
 
-Optionally, you may raise an error and fail the build on bad url status.
+Optionally, you may raise an error and fail the build on first bad url status.
 
 ```yaml
 plugins:
@@ -65,9 +65,19 @@ plugins:
       raise_error: True
 ```
 
+### `raise_error_after_finish`
+
+Optionally, you may want to raise an error and fail the build on at least one bad url status after all links have been checked.
+
+```yaml
+plugins:
+  - htmlproofer:
+      raise_error_after_finish: True
+```
+
 ### `raise_error_excludes`
 
-When specifying `raise_error: True`, it is possible to ignore errors
+When specifying `raise_error: True` or `raise_error_after_finish: True`, it is possible to ignore errors
 for combinations of urls (`'*'` means all urls) and status codes with `raise_error_excludes`.
 
 ```yaml

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -85,7 +85,7 @@ def test_on_post_page(empty_files, mock_requests, validate_rendered_template, ra
             plugin.on_post_page(link_to_500 if validate_rendered_template else '', page, config)
     else:
         plugin.on_post_page(link_to_500 if validate_rendered_template else '', page, config)
-        plugin.invalid_links = raise_error_after_finish_template
+        assert plugin.invalid_links == raise_error_after_finish_template
 
 
 def test_on_post_page__plugin_disabled():

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -29,15 +29,43 @@ def mock_requests():
         mock_head.side_effect = Exception("don't make network requests from tests")
         yield mock_head
 
+@pytest.mark.parametrize(
+    'raise_error_after_finish_template', (False, True)
+)
+@pytest.mark.parametrize(
+    'invalid_links_template', (False, True)
+)
+def test_on_post_build(raise_error_after_finish_template, invalid_links_template):
+    plugin = HtmlProoferPlugin()
+    plugin.load_config({
+        'raise_error_after_finish': raise_error_after_finish_template,
+    })
+
+    plugin.invalid_links = invalid_links_template
+    config = Mock(spec=Config)
+
+    if invalid_links_template and raise_error_after_finish_template:
+        with pytest.raises(PluginError):
+            plugin.on_post_build(config)
+    else:
+        plugin.on_post_build(config)
+
 
 @pytest.mark.parametrize(
     'validate_rendered_template', (False, True)
 )
-def test_on_post_page(empty_files, mock_requests, validate_rendered_template):
+@pytest.mark.parametrize(
+    'raise_error_template', (False, True)
+)
+@pytest.mark.parametrize(
+    'raise_error_after_finish_template', (False, True)
+)
+def test_on_post_page(empty_files, mock_requests, validate_rendered_template, raise_error_template, raise_error_after_finish_template):
     plugin = HtmlProoferPlugin()
     plugin.load_config({
         'validate_rendered_template': validate_rendered_template,
-        'raise_error': True,
+        'raise_error': raise_error_template,
+        'raise_error_after_finish':raise_error_after_finish_template,
     })
 
     # Always raise a 500 error
@@ -52,8 +80,12 @@ def test_on_post_page(empty_files, mock_requests, validate_rendered_template):
     )
     config = Mock(spec=Config, data={'use_directory_urls': False})
 
-    with pytest.raises(PluginError):
+    if raise_error_template:
+        with pytest.raises(PluginError):
+            plugin.on_post_page(link_to_500 if validate_rendered_template else '', page, config)
+    else:
         plugin.on_post_page(link_to_500 if validate_rendered_template else '', page, config)
+        plugin.invalid_links = raise_error_after_finish_template
 
 
 def test_on_post_page__plugin_disabled():


### PR DESCRIPTION
Right now if user wants to get all invalid links printed in a project configured with raise_error the options are:

1. Comment out raise_error option locally and see them all. Fix them and bring back raise_error option.
2. Run build many times - huge amount of times in case of many broken links.

It would be nice to have an option to see all invalid links listed on failed builds. This commit introduces "raise_error_after_finish" to allow that.