### PR TITLE
Show bad configured CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 htmlproofer/ tests/ setup.py --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 htmlproofer/ tests/ setup.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Type Check with mypy
         run: mypy htmlproofer
       - name: Check Import Ordering with isort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           # stop the build if there are Python syntax errors or undefined names
           flake8 htmlproofer/ tests/ setup.py --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 htmlproofer/ tests/ setup.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 htmlproofer/ tests/ setup.py --count --max-complexity=10 --max-line-length=127 --statistics
       - name: Type Check with mypy
         run: mypy htmlproofer
       - name: Check Import Ordering with isort

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -56,7 +56,7 @@ class HtmlProoferPlugin(BasePlugin):
         self.files = {}
         super().__init__()
 
-    def on_post_build(self, config: Config)-> None:
+    def on_post_build(self, config: Config) -> None:
         if self.config['raise_error_after_finish'] and self.invalid_links:
             raise PluginError("Invalid links present.")
 
@@ -107,8 +107,14 @@ class HtmlProoferPlugin(BasePlugin):
         except requests.exceptions.ConnectionError:
             return -1
 
-    def get_url_status(self, url: str, src_path: str, all_element_ids: Set[str], files: Dict[str, File],
-        use_directory_urls: bool) -> int:
+    def get_url_status(
+            self,
+            url: str,
+            src_path: str,
+            all_element_ids: Set[str],
+            files: Dict[str, File],
+            use_directory_urls: bool
+    ) -> int:
         if any(pat.match(url) for pat in LOCAL_PATTERNS):
             return 0
 
@@ -197,7 +203,7 @@ class HtmlProoferPlugin(BasePlugin):
                     if anchor == attr_list_anchor:
                         return True
 
-                heading = re.sub(ATTRLIST_PATTERN, '', heading) # remove any attribute list from heading, before slugify
+                heading = re.sub(ATTRLIST_PATTERN, '', heading)  # remove any attribute list from heading, before slugify
 
                 # Headings are allowed to have images after them, of the form:
                 # # Heading [![Image](image-link)] or ![Image][image-reference]
@@ -212,8 +218,8 @@ class HtmlProoferPlugin(BasePlugin):
             if link_match is not None and link_match.group(1) == anchor:
                 return True
 
-            # Any attribute list at end of paragraphs or after images can also generate an anchor (in addition to the heading ones)
-            # so gather those and check as well (multiple could be a line so gather all)
+            # Any attribute list at end of paragraphs or after images can also generate an anchor (in addition to
+            # the heading ones) so gather those and check as well (multiple could be a line so gather all)
             for attr_list_anchor in re.findall(ATTRLIST_ANCHOR_PATTERN, line):
                 if anchor == attr_list_anchor:
                     return True

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -124,7 +124,7 @@ def test_get_url_status(validate_external: bool):
     plugin.load_config({'validate_external_urls': validate_external})
 
     def get_url():
-        plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
+        return plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
 
     if validate_external:
         with pytest.raises(Exception):

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -29,6 +29,7 @@ def mock_requests():
         mock_head.side_effect = Exception("don't make network requests from tests")
         yield mock_head
 
+
 @pytest.mark.parametrize(
     'raise_error_after_finish_template', (False, True)
 )
@@ -60,12 +61,18 @@ def test_on_post_build(raise_error_after_finish_template, invalid_links_template
 @pytest.mark.parametrize(
     'raise_error_after_finish_template', (False, True)
 )
-def test_on_post_page(empty_files, mock_requests, validate_rendered_template, raise_error_template, raise_error_after_finish_template):
+def test_on_post_page(
+        empty_files,
+        mock_requests,
+        validate_rendered_template,
+        raise_error_template,
+        raise_error_after_finish_template
+):
     plugin = HtmlProoferPlugin()
     plugin.load_config({
         'validate_rendered_template': validate_rendered_template,
         'raise_error': raise_error_template,
-        'raise_error_after_finish':raise_error_after_finish_template,
+        'raise_error_after_finish': raise_error_after_finish_template,
     })
 
     # Always raise a 500 error
@@ -116,7 +123,8 @@ def test_get_url_status(validate_external: bool):
     plugin = HtmlProoferPlugin()
     plugin.load_config({'validate_external_urls': validate_external})
 
-    get_url = lambda: plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
+    def get_url():
+        plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
 
     if validate_external:
         with pytest.raises(Exception):
@@ -139,16 +147,27 @@ def test_get_url_status(validate_external: bool):
         (r'## Heading {: #customanchor}', 'customanchor', True),
         (r'## Heading {.customclass #customanchor}', 'customanchor', True),
         (r'## refer to this ![image](image-link){#imageanchorheading}', 'imageanchorheading', True),
-        (r'## refer to this ![image](image-link){.customclass}', 'refer-to-this-imageimage-link', True), # test faulty image in heading syntax
+        # test faulty image in heading syntax
+        (r'## refer to this ![image](image-link){.customclass}', 'refer-to-this-imageimage-link', True),
+
         (r'## refer to this [![image](image-link){#imageanchorheading}]', 'imageanchorheading', True),
-        (r'see image ![image](image-link){#imageanchor1} see image 2 ![image](image-link){#imageanchor2}', 'imageanchor1', True),
-        (r'see image ![image](image-link){#imageanchor1} see image 2 ![image](image-link){#imageanchor2}', 'imageanchor2', True),
+        (
+                r'see image ![image](image-link){#imageanchor1} see image 2 ![image](image-link){#imageanchor2}',
+                'imageanchor1',
+                True
+        ),
+        (
+                r'see image ![image](image-link){#imageanchor1} see image 2 ![image](image-link){#imageanchor2}',
+                'imageanchor2',
+                True
+        ),
         (r'paragraph text\n{#paragraphanchor}', 'paragraphanchor', True),
         (r'paragraph text\n{#paragraphanchor test', 'paragraphanchor', False),
     ]
 )
 def test_contains_anchor(plugin, markdown, anchor, expected):
     assert plugin.contains_anchor(markdown, anchor) == expected
+
 
 def test_get_url_status__same_page_anchor(plugin, empty_files):
     assert plugin.get_url_status('#ref', 'src/path.md', {'ref'}, empty_files, False) == 0
@@ -193,7 +212,6 @@ def test_get_url_status__local_page(plugin):
 
 def test_get_url_status__non_markdown_page(plugin):
     index_page = Mock(spec=Page, markdown='# Heading\nContent')
-    page1_page = Mock(spec=Page, markdown='# Page One\n## Sub Heading\nContent')
     files = {os.path.normpath(file.url): file for file in Files([
         Mock(spec=File, src_path='index.md', dest_path='index.html', url='index.html', page=index_page),
         Mock(spec=File, src_path='drawing.svg', dest_path='drawing.svg', url='drawing.svg', page=None),
@@ -212,10 +230,34 @@ def test_get_url_status__local_page_nested(plugin):
     nested2_sibling_page = Mock(spec=Page, markdown='# Nested Sibling')
     files = {os.path.normpath(file.url): file for file in Files([
         Mock(spec=File, src_path='index.md', dest_path='index.html', url='index.html', page=index_page),
-        Mock(spec=File, src_path='foo/bar/nested.md', dest_path='foo/bar/nested.html', url='foo/bar/nested.html', page=nested1_page),
-        Mock(spec=File, src_path='foo/bar/sibling.md', dest_path='foo/bar/sibling.html', url='foo/bar/sibling.html', page=nested1_sibling_page),
-        Mock(spec=File, src_path='foo/baz/nested.md', dest_path='foo/baz/nested.html', url='foo/baz/nested.html', page=nested2_page),
-        Mock(spec=File, src_path='foo/baz/sibling.md', dest_path='foo/baz/sibling.html', url='foo/baz/sibling.html', page=nested2_sibling_page),
+        Mock(
+            spec=File,
+            src_path='foo/bar/nested.md',
+            dest_path='foo/bar/nested.html',
+            url='foo/bar/nested.html',
+            page=nested1_page
+        ),
+        Mock(
+            spec=File,
+            src_path='foo/bar/sibling.md',
+            dest_path='foo/bar/sibling.html',
+            url='foo/bar/sibling.html',
+            page=nested1_sibling_page
+        ),
+        Mock(
+            spec=File,
+            src_path='foo/baz/nested.md',
+            dest_path='foo/baz/nested.html',
+            url='foo/baz/nested.html',
+            page=nested2_page
+        ),
+        Mock(
+            spec=File,
+            src_path='foo/baz/sibling.md',
+            dest_path='foo/baz/sibling.html',
+            url='foo/baz/sibling.html',
+            page=nested2_sibling_page
+        ),
     ])}
 
     assert plugin.get_url_status('nested.html#nested-one', 'foo/bar/sibling.md', set(), files, False) == 0


### PR DESCRIPTION
@manuzhang 

Your CI is green even if it contains styling-issues:
e.g. https://github.com/manuzhang/mkdocs-htmlproofer-plugin/actions/runs/4637384298/jobs/8206224207?pr=55
![image](https://user-images.githubusercontent.com/48681214/230592026-93cab530-f9f1-4a80-8d6a-2acff8cd59ea.png)

There are two issues:
* You should specify folder names instead of `.`
* `--exit-zero` is most likely not want you want

I'm going to solve all issues with my next PR. I noticed it after my implementation, so it would be easier to adress it there.