### PR TITLE
Consider url scheme to detect and handle external URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 htmlproofer/ tests/ setup.py --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 htmlproofer/ tests/ setup.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Type Check with mypy
         run: mypy htmlproofer
       - name: Check Import Ordering with isort

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           # stop the build if there are Python syntax errors or undefined names
           flake8 htmlproofer/ tests/ setup.py --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 htmlproofer/ tests/ setup.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          flake8 htmlproofer/ tests/ setup.py --count --max-complexity=10 --max-line-length=127 --statistics
       - name: Type Check with mypy
         run: mypy htmlproofer
       - name: Check Import Ordering with isort

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -5,6 +5,7 @@ import re
 import sys
 from typing import Dict, Optional, Set
 import uuid
+import urllib.parse
 
 from bs4 import BeautifulSoup, SoupStrainer
 from markdown.extensions.toc import slugify
@@ -112,12 +113,13 @@ class HtmlProoferPlugin(BasePlugin):
         if any(pat.match(url) for pat in LOCAL_PATTERNS):
             return 0
 
-        if url.startswith('#'):
-            return 0 if url[1:] in all_element_ids else 404
-        elif EXTERNAL_URL_PATTERN.match(url):
+        scheme, _, path, _, fragment = urllib.parse.urlsplit(url)
+        if scheme:
             if not self.config['validate_external_urls']:
                 return 0
             return self.get_external_url(url)
+        if fragment and not path:
+            return 0 if url[1:] in all_element_ids else 404
         elif not use_directory_urls:
             # use_directory_urls = True injects too many challenges for locating the correct target
             # Markdown file, so disable target anchor validation in this case. Examples include:

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -36,9 +36,17 @@ ATTRLIST_PATTERN = re.compile(r'\{.*?\}')
 urllib3.disable_warnings()
 
 
-log_info = lambda msg, *args, **kwargs: utils.log.info(f"{NAME}: {msg}", *args, **kwargs)
-log_warning = lambda msg, *args, **kwargs: utils.log.warning(f"{NAME}: {msg}", *args, **kwargs)
-log_error = lambda msg, *args, **kwargs: utils.log.error(f"{NAME}: {msg}", *args, **kwargs)
+def log_info(msg, *args, **kwargs):
+    utils.log.info(f"{NAME}: {msg}", *args, **kwargs)
+
+
+def log_warning(msg, *args, **kwargs):
+    utils.log.warning(f"{NAME}: {msg}", *args, **kwargs)
+
+
+def log_error(msg, *args, **kwargs):
+    utils.log.error(f"{NAME}: {msg}", *args, **kwargs)
+
 
 class HtmlProoferPlugin(BasePlugin):
     files: Dict[str, File]
@@ -65,7 +73,7 @@ class HtmlProoferPlugin(BasePlugin):
         }
         super().__init__()
 
-    def on_post_build(self, config: Config)-> None:
+    def on_post_build(self, config: Config) -> None:
         if self.config['raise_error_after_finish'] and self.invalid_links:
             raise PluginError("Invalid links present.")
 
@@ -124,8 +132,14 @@ class HtmlProoferPlugin(BasePlugin):
         except requests.exceptions.ConnectionError:
             return -1
 
-    def get_url_status(self, url: str, src_path: str, all_element_ids: Set[str], files: Dict[str, File],
-        use_directory_urls: bool) -> int:
+    def get_url_status(
+            self,
+            url: str,
+            src_path: str,
+            all_element_ids: Set[str],
+            files: Dict[str, File],
+            use_directory_urls: bool
+    ) -> int:
         if any(pat.match(url) for pat in LOCAL_PATTERNS):
             return 0
 
@@ -215,7 +229,7 @@ class HtmlProoferPlugin(BasePlugin):
                     if anchor == attr_list_anchor:
                         return True
 
-                heading = re.sub(ATTRLIST_PATTERN, '', heading) # remove any attribute list from heading, before slugify
+                heading = re.sub(ATTRLIST_PATTERN, '', heading)  # remove any attribute list from heading, before slugify
 
                 # Headings are allowed to have images after them, of the form:
                 # # Heading [![Image](image-link)] or ![Image][image-reference]
@@ -230,8 +244,8 @@ class HtmlProoferPlugin(BasePlugin):
             if link_match is not None and link_match.group(1) == anchor:
                 return True
 
-            # Any attribute list at end of paragraphs or after images can also generate an anchor (in addition to the heading ones)
-            # so gather those and check as well (multiple could be a line so gather all)
+            # Any attribute list at end of paragraphs or after images can also generate an anchor (in addition to
+            # the heading ones) so gather those and check as well (multiple could be a line so gather all)
             for attr_list_anchor in re.findall(ATTRLIST_ANCHOR_PATTERN, line):
                 if anchor == attr_list_anchor:
                     return True

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -3,8 +3,8 @@ import os.path
 import pathlib
 import re
 from typing import Dict, Optional, Set
-import uuid
 import urllib.parse
+import uuid
 
 from bs4 import BeautifulSoup, SoupStrainer
 from markdown.extensions.toc import slugify

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -105,6 +105,13 @@ class HtmlProoferPlugin(BasePlugin):
                 if is_error:
                     log_warning(error)
 
+    def get_external_url(self, url, scheme, src_path):
+        try:
+            return self.scheme_handlers[scheme](url)
+        except KeyError:
+            log_info(f'Unknown url-scheme "{scheme}:" detected. "{url}" from "{src_path}" will not be checked.')
+        return 0
+
     @lru_cache(maxsize=1000)
     def resolve_web_scheme(self, url: str) -> int:
         try:
@@ -125,13 +132,7 @@ class HtmlProoferPlugin(BasePlugin):
         scheme, _, path, _, fragment = urllib.parse.urlsplit(url)
         if scheme:
             if self.config['validate_external_urls']:
-                try:
-                    return self.scheme_handlers[scheme](url)
-                except KeyError:
-                    log_info(
-                        f'mkdocs-htmlproofer: Unknown url-scheme "{scheme}:" detected. "'
-                        f'"{url}" from "{src_path}" will not be checked.'
-                    )
+                return self.get_external_url(url, scheme, src_path)
             return 0
         if fragment and not path:
             return 0 if url[1:] in all_element_ids else 404

--- a/tests/integration/docs/index.md
+++ b/tests/integration/docs/index.md
@@ -81,3 +81,16 @@ This work is based on the [mkdocs-markdownextradata-plugin](https://github.com/r
 <a href="assets/hello-world.drawio.svg">![test](assets/hello-world.drawio.svg)</a>
 
 <a href="/assets/hello-world.drawio.svg">![test](/assets/hello-world.drawio.svg)</a>
+
+## External URLs
+
+External urls starting with `http` or `https` are checked.
+
+- <http://github.com>
+- <https://github.com>
+
+## Custom schemes
+
+Unkown schemes like `mailto` are ignored.
+
+- <mailto:info@github.com>

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -162,13 +162,18 @@ def test_get_url_status__same_page_anchor(plugin, empty_files):
         'https://extwebsite.com',
         'http://extwebsite.com',
         'https://website.net/path#anchor',
+        'mailto:toto@toto.com',
+        'steam://application',
+        'file://file',
     ),
 )
 def test_get_url_status__external(plugin, empty_files, url):
+    src_path = 'src/path.md'
+    scheme = url.split(":")[0]
     with patch.object(HtmlProoferPlugin, "get_external_url") as mock_get_ext_url:
         mock_get_ext_url.return_value = 200
-        assert plugin.get_url_status(url, 'src/path.md', set(), empty_files, False) == 200
-    mock_get_ext_url.assert_called_once_with(url)
+        assert plugin.get_url_status(url, src_path, set(), empty_files, False) == 200
+    mock_get_ext_url.assert_called_once_with(url, scheme, src_path)
 
 
 def test_get_url_status__local_page(plugin):

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -125,7 +125,7 @@ def test_get_url_status(validate_external: bool):
     plugin.load_config({'validate_external_urls': validate_external})
 
     def get_url():
-        plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
+        return plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
 
     if validate_external:
         with pytest.raises(Exception):

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -203,7 +203,7 @@ def test_get_url_status__external(plugin, empty_files, url):
 @pytest.mark.parametrize("scheme", ('http', 'https'))
 def test_get_external_url__web_scheme(scheme):
     src_path = 'src/path.md'
-    url = scheme + "://path.html"
+    url = f"{scheme}://path.html"
     expected_status = 200
 
     with patch.object(HtmlProoferPlugin, "resolve_web_scheme") as mock_resolve_web_scheme:
@@ -220,7 +220,7 @@ def test_get_external_url__web_scheme(scheme):
 @pytest.mark.parametrize("scheme", ('mailto', 'file', 'steam', 'abc'))
 def test_get_external_url__unknown_scheme(scheme):
     src_path = 'src/path.md'
-    url = scheme + "://path.html"
+    url = f"{scheme}://path.html"
     expected_status = 0
 
     with patch.object(HtmlProoferPlugin, "resolve_web_scheme") as mock_resolve_web_scheme:

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -170,10 +170,14 @@ def test_get_url_status__same_page_anchor(plugin, empty_files):
 def test_get_url_status__external(plugin, empty_files, url):
     src_path = 'src/path.md'
     scheme = url.split(":")[0]
+    expected_status = 200
+
     with patch.object(HtmlProoferPlugin, "get_external_url") as mock_get_ext_url:
-        mock_get_ext_url.return_value = 200
-        assert plugin.get_url_status(url, src_path, set(), empty_files, False) == 200
+        mock_get_ext_url.return_value = expected_status
+        status = plugin.get_url_status(url, src_path, set(), empty_files, False)
+
     mock_get_ext_url.assert_called_once_with(url, scheme, src_path)
+    assert status == expected_status
 
 
 def test_get_url_status__local_page(plugin):

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,11 +1,11 @@
 import os.path
 from unittest.mock import Mock, patch
 
-import mkdocs.utils
 from mkdocs.config import Config
 from mkdocs.exceptions import PluginError
 from mkdocs.structure.files import File, Files
 from mkdocs.structure.pages import Page
+import mkdocs.utils
 import pytest
 from requests import Response
 

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -30,6 +30,7 @@ def mock_requests():
         mock_head.side_effect = Exception("don't make network requests from tests")
         yield mock_head
 
+
 @pytest.mark.parametrize(
     'raise_error_after_finish_template', (False, True)
 )
@@ -61,12 +62,18 @@ def test_on_post_build(raise_error_after_finish_template, invalid_links_template
 @pytest.mark.parametrize(
     'raise_error_after_finish_template', (False, True)
 )
-def test_on_post_page(empty_files, mock_requests, validate_rendered_template, raise_error_template, raise_error_after_finish_template):
+def test_on_post_page(
+        empty_files,
+        mock_requests,
+        validate_rendered_template,
+        raise_error_template,
+        raise_error_after_finish_template
+):
     plugin = HtmlProoferPlugin()
     plugin.load_config({
         'validate_rendered_template': validate_rendered_template,
         'raise_error': raise_error_template,
-        'raise_error_after_finish':raise_error_after_finish_template,
+        'raise_error_after_finish': raise_error_after_finish_template,
     })
 
     # Always raise a 500 error
@@ -117,7 +124,8 @@ def test_get_url_status(validate_external: bool):
     plugin = HtmlProoferPlugin()
     plugin.load_config({'validate_external_urls': validate_external})
 
-    get_url = lambda: plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
+    def get_url():
+        plugin.get_url_status('https://google.com', 'src/path.md', set(), empty_files, False)
 
     if validate_external:
         with pytest.raises(Exception):
@@ -140,16 +148,27 @@ def test_get_url_status(validate_external: bool):
         (r'## Heading {: #customanchor}', 'customanchor', True),
         (r'## Heading {.customclass #customanchor}', 'customanchor', True),
         (r'## refer to this ![image](image-link){#imageanchorheading}', 'imageanchorheading', True),
-        (r'## refer to this ![image](image-link){.customclass}', 'refer-to-this-imageimage-link', True), # test faulty image in heading syntax
+        # test faulty image in heading syntax
+        (r'## refer to this ![image](image-link){.customclass}', 'refer-to-this-imageimage-link', True),
+
         (r'## refer to this [![image](image-link){#imageanchorheading}]', 'imageanchorheading', True),
-        (r'see image ![image](image-link){#imageanchor1} see image 2 ![image](image-link){#imageanchor2}', 'imageanchor1', True),
-        (r'see image ![image](image-link){#imageanchor1} see image 2 ![image](image-link){#imageanchor2}', 'imageanchor2', True),
+        (
+                r'see image ![image](image-link){#imageanchor1} see image 2 ![image](image-link){#imageanchor2}',
+                'imageanchor1',
+                True
+        ),
+        (
+                r'see image ![image](image-link){#imageanchor1} see image 2 ![image](image-link){#imageanchor2}',
+                'imageanchor2',
+                True
+        ),
         (r'paragraph text\n{#paragraphanchor}', 'paragraphanchor', True),
         (r'paragraph text\n{#paragraphanchor test', 'paragraphanchor', False),
     ]
 )
 def test_contains_anchor(plugin, markdown, anchor, expected):
     assert plugin.contains_anchor(markdown, anchor) == expected
+
 
 def test_get_url_status__same_page_anchor(plugin, empty_files):
     assert plugin.get_url_status('#ref', 'src/path.md', {'ref'}, empty_files, False) == 0
@@ -194,7 +213,7 @@ def test_get_external_url__web_scheme(scheme):
 
         status = plugin.get_external_url(url, scheme, src_path)
 
-    mock_resolve_web_scheme.assert_called_once_with(plugin ,url)
+    mock_resolve_web_scheme.assert_called_once_with(plugin, url)
     assert status == expected_status
 
 
@@ -239,7 +258,6 @@ def test_get_url_status__local_page(plugin):
 
 def test_get_url_status__non_markdown_page(plugin):
     index_page = Mock(spec=Page, markdown='# Heading\nContent')
-    page1_page = Mock(spec=Page, markdown='# Page One\n## Sub Heading\nContent')
     files = {os.path.normpath(file.url): file for file in Files([
         Mock(spec=File, src_path='index.md', dest_path='index.html', url='index.html', page=index_page),
         Mock(spec=File, src_path='drawing.svg', dest_path='drawing.svg', url='drawing.svg', page=None),
@@ -258,10 +276,34 @@ def test_get_url_status__local_page_nested(plugin):
     nested2_sibling_page = Mock(spec=Page, markdown='# Nested Sibling')
     files = {os.path.normpath(file.url): file for file in Files([
         Mock(spec=File, src_path='index.md', dest_path='index.html', url='index.html', page=index_page),
-        Mock(spec=File, src_path='foo/bar/nested.md', dest_path='foo/bar/nested.html', url='foo/bar/nested.html', page=nested1_page),
-        Mock(spec=File, src_path='foo/bar/sibling.md', dest_path='foo/bar/sibling.html', url='foo/bar/sibling.html', page=nested1_sibling_page),
-        Mock(spec=File, src_path='foo/baz/nested.md', dest_path='foo/baz/nested.html', url='foo/baz/nested.html', page=nested2_page),
-        Mock(spec=File, src_path='foo/baz/sibling.md', dest_path='foo/baz/sibling.html', url='foo/baz/sibling.html', page=nested2_sibling_page),
+        Mock(
+            spec=File,
+            src_path='foo/bar/nested.md',
+            dest_path='foo/bar/nested.html',
+            url='foo/bar/nested.html',
+            page=nested1_page
+        ),
+        Mock(
+            spec=File,
+            src_path='foo/bar/sibling.md',
+            dest_path='foo/bar/sibling.html',
+            url='foo/bar/sibling.html',
+            page=nested1_sibling_page
+        ),
+        Mock(
+            spec=File,
+            src_path='foo/baz/nested.md',
+            dest_path='foo/baz/nested.html',
+            url='foo/baz/nested.html',
+            page=nested2_page
+        ),
+        Mock(
+            spec=File,
+            src_path='foo/baz/sibling.md',
+            dest_path='foo/baz/sibling.html',
+            url='foo/baz/sibling.html',
+            page=nested2_sibling_page
+        ),
     ])}
 
     assert plugin.get_url_status('nested.html#nested-one', 'foo/bar/sibling.md', set(), files, False) == 0


### PR DESCRIPTION
This PR improves the plugin by doing two things:

* External urls are detected via scheme
* External urls are handled regarding their scheme

Further, I improved the logging by using the provided functionality of `mkdocs.utils.log`.

Unfortunately, I noticed there are several `flake8` issues in the existing code after my changes.
They are not correctly recognized like I showed in #55.
I fixed them all in this branch, I would prefer if we could merge those changes pragmatic in that PR and avoid a extract and conflict resolution.

Closes #54 
Closes #55 