### PR TITLE
Add support for ignoring URLs (no fetching) with wildcards.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,38 @@ plugins:
         400: ['*']
 ```
 
+### `ignore_urls`
+
+Avoid validating the given list of URLs by ignoring them altogether. Each URL in the
+list support unix style wildcards `*`, `[]`, `?`, etc.
+
+Unlike `raise_error_excludes`, ignored URLs will not be fetched at all.
+
+```yaml
+plugins:
+  - search
+  - htmlproofer:
+      raise_error: True
+      ignore_urls:
+        - https://github.com/myprivateorg/*
+        - https://app.dynamic-service-of-some-kind.io*
+```
+
+### `warn_on_ignored_urls`
+
+Log a warning when ignoring URLs with `ignore_urls` option. Defaults to `false` (no warning).
+
+```yaml
+plugins:
+  - search
+  - htmlproofer:
+      raise_error: True
+      ignore_urls:
+        - https://github.com/myprivateorg/*
+        - https://app.dynamic-service-of-some-kind.io*
+      warn_on_ignored_urls: true
+```
+
 ### `validate_external_urls`
 
 Avoids validating any external URLs (i.e those starting with http:// or https://).

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -5,6 +5,7 @@ import re
 from typing import Dict, Optional, Set
 import urllib.parse
 import uuid
+import fnmatch
 
 from bs4 import BeautifulSoup, SoupStrainer
 from markdown.extensions.toc import slugify
@@ -59,6 +60,8 @@ class HtmlProoferPlugin(BasePlugin):
         ('raise_error_excludes', config_options.Type(dict, default={})),
         ('validate_external_urls', config_options.Type(bool, default=True)),
         ('validate_rendered_template', config_options.Type(bool, default=False)),
+        ('ignore_urls', config_options.Type(list, default=[])),
+        ('warn_on_ignored_urls', config_options.Type(bool, default=False)),
     )
 
     def __init__(self):
@@ -98,6 +101,16 @@ class HtmlProoferPlugin(BasePlugin):
         all_element_ids.add('')  # Empty anchor is commonly used, but not real
         for a in soup.find_all('a', href=True):
             url = a['href']
+
+            ignore = False
+            for ignore_url_exp in self.config['ignore_urls']:
+                if fnmatch.fnmatch(url, ignore_url_exp):
+                    ignore = True
+                    break
+            if ignore:
+                if self.config['warn_on_ignored_urls']:
+                    log_warning(f"ignoring URL {url} from {page.file.src_path}")
+                continue
 
             url_status = self.get_url_status(url, page.file.src_path, all_element_ids, self.files, use_directory_urls)
 

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -1,3 +1,4 @@
+import fnmatch
 from functools import lru_cache, partial
 import os.path
 import pathlib
@@ -5,7 +6,6 @@ import re
 from typing import Dict, Optional, Set
 import urllib.parse
 import uuid
-import fnmatch
 
 from bs4 import BeautifulSoup, SoupStrainer
 from markdown.extensions.toc import slugify


### PR DESCRIPTION
Support ignoring a configurable list of URLs.

Useful when a documentation project has a lot of URLs that are not reachable or that are not authorized to access without additional cookies. Organization level Github private repositories are a good example.