### PR TITLE
Allow special characters in directory name, optimization

### DIFF
--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -223,7 +223,8 @@ class HtmlProoferPlugin(BasePlugin):
             search_path = os.path.normpath(url[1:])
         else:
             # Handle relative links by concatenating the source dir with the destination path
-            search_path = os.path.normpath(str(pathlib.Path(src_path).parent / pathlib.Path(url)))
+            src_dir = urllib.parse.quote(str(pathlib.Path(src_path).parent))
+            search_path = os.path.normpath(str(pathlib.Path(src_dir) / pathlib.Path(url)))
 
         try:
             return files[search_path]

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -87,7 +87,7 @@ class HtmlProoferPlugin(BasePlugin):
         if self.config['raise_error_after_finish'] and self.invalid_links:
             raise PluginError("Invalid links present.")
 
-    def on_page_markdown(self, markdown: str, page: Page, config: Config, files: Files) -> None:
+    def on_files(self, files: Files, config: Config) -> None:
         # Store files to allow inspecting Markdown files in later stages.
         self.files.update({os.path.normpath(file.url): file for file in files})
 

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -240,9 +240,11 @@ def test_get_external_url__unknown_scheme(scheme):
 def test_get_url_status__local_page(plugin):
     index_page = Mock(spec=Page, markdown='# Heading\nContent')
     page1_page = Mock(spec=Page, markdown='# Page One\n## Sub Heading\nContent')
+    special_char_page = Mock(spec=Page, markdown='# Heading éèà\n## Sub Heading éèà\nContent')
     files = {os.path.normpath(file.url): file for file in Files([
         Mock(spec=File, src_path='index.md', dest_path='index.html', url='index.html', page=index_page),
         Mock(spec=File, src_path='page1.md', dest_path='page1.html', url='page1.html', page=page1_page),
+        Mock(spec=File, src_path='Dir éèà/éèà.md', dest_path='Dir éèà/éèà.html', url='Dir%20%C3%A9%C3%A8%C3%A0/%C3%A9%C3%A8%C3%A0.html', page=special_char_page),
     ])}
 
     assert plugin.get_url_status('index.html', 'page1.md', set(), files, False) == 0
@@ -256,6 +258,9 @@ def test_get_url_status__local_page(plugin):
     assert plugin.get_url_status('page2.html', 'page1.md', set(), files, False) == 404
     assert plugin.get_url_status('page2.html#heading', 'page1.md', set(), files, False) == 404
 
+    assert plugin.get_url_status('Dir%20%C3%A9%C3%A8%C3%A0/%C3%A9%C3%A8%C3%A0.html#sub-heading-eea', 'page1.md', set(), files, False) == 0
+    assert plugin.get_url_status('%C3%A9%C3%A8%C3%A0.html#sub-heading-eea', 'Dir éèà/page3.md', set(), files, False) == 0
+    
 
 def test_get_url_status__non_markdown_page(plugin):
     index_page = Mock(spec=Page, markdown='# Heading\nContent')


### PR DESCRIPTION
The keys of `self.files` are url encoded. This leads to errors when the path of a file contains special characters as `src_path` is not url encoded.

Modifications:

- url encode the directory path
- generate `self.files` in the `on_files()` function instead of `on_page_markdown()` (this is only an optimization, not strictly needed)
- test (directory with special characters)