### PR TITLE
Add option to optionally skip downloading the contents of a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ plugins:
       validate_rendered_template: True
 ```
 
+### `skip_downloads`
+
+Optionally skip downloading of a remote URLs content via GET request. This can
+considerably reduce the time taken to validate URLs.
+
+```yaml
+plugins:
+  - htmlproofer:
+      skip_downloads: True
+```
+
 ## Compatibility with `attr_list` extension
 
 If you need to manually specify anchors make use of the `attr_list` [extension](https://python-markdown.github.io/extensions/attr_list) in the markdown.

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -146,7 +146,12 @@ class HtmlProoferPlugin(BasePlugin):
     @lru_cache(maxsize=1000)
     def resolve_web_scheme(self, url: str) -> int:
         try:
-            response = self._session.get(url, timeout=URL_TIMEOUT)
+            response = self._session.get(url, timeout=URL_TIMEOUT, stream=True)
+
+            # Download the entire contents as to not break previous behaviour.
+            for _ in response.iter_content(chunk_size=1024):
+                pass
+
             return response.status_code
         except requests.exceptions.Timeout:
             return 504

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -65,6 +65,7 @@ class HtmlProoferPlugin(BasePlugin):
         ('raise_error', config_options.Type(bool, default=False)),
         ('raise_error_after_finish', config_options.Type(bool, default=False)),
         ('raise_error_excludes', config_options.Type(dict, default={})),
+        ('skip_downloads', config_options.Type(bool, default=False)),
         ('validate_external_urls', config_options.Type(bool, default=True)),
         ('validate_rendered_template', config_options.Type(bool, default=False)),
         ('ignore_urls', config_options.Type(list, default=[])),
@@ -148,9 +149,10 @@ class HtmlProoferPlugin(BasePlugin):
         try:
             response = self._session.get(url, timeout=URL_TIMEOUT, stream=True)
 
-            # Download the entire contents as to not break previous behaviour.
-            for _ in response.iter_content(chunk_size=1024):
-                pass
+            if self.config['skip_downloads'] is False:
+                # Download the entire contents as to not break previous behaviour.
+                for _ in response.iter_content(chunk_size=1024):
+                    pass
 
             return response.status_code
         except requests.exceptions.Timeout:

--- a/tests/integration/mkdocs.yml
+++ b/tests/integration/mkdocs.yml
@@ -16,3 +16,4 @@ plugins:
             'page2.html#BAD_ANCHOR',
             '../../../tests',
           ]
+        skip_downloads: True

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -78,8 +78,10 @@ def test_on_post_page(
     })
 
     # Always raise a 500 error
-    mock_requests.side_effect = [Mock(spec=Response, status_code=500)]
     link_to_500 = '<a href="https://google.com"><a/>'
+    iter_content = Mock()
+    iter_content.side_effect = link_to_500
+    mock_requests.side_effect = [Mock(spec=Response, status_code=500, iter_content=iter_content)]
 
     plugin.files = empty_files
     page = Mock(


### PR DESCRIPTION
This PR does a couple of things:

1 . The first commit prevents the downloading of entire files into memory by streaming the response and reading small chunks as a time. 
2. The second commit adds the configuration option to optionally skip downloading of a remote URLs content.

Closes https://github.com/manuzhang/mkdocs-htmlproofer-plugin/issues/76.