### PR TITLE
Rework use_directory_url=True validation to better catch incorrect links

### DIFF
--- a/tests/integration/docs/nested/page1.md
+++ b/tests/integration/docs/nested/page1.md
@@ -19,11 +19,14 @@ This plugin can detect invalid anchor links to another page, such as
 [Acknowledgement](../index.md#BAD_ANCHOR)
 or to a nested page
 [Invalid Anchor](./page2.md#BAD_ANCHOR).
+It should also detect links to pages in the same directory without './'
+[Invalid Anchor](page2.md#BAD_ANCHOR).
 
 But allows valid anchors such as
 [Main Page](../index.md#mkdocs-htmlproofer-plugin),
-[Table of Contents](../index.md#table-of-contents), and
-[Emoji Anchor](./page2.md#title-with-emojis).
+[Table of Contents](../index.md#table-of-contents),
+[Emoji Anchor](./page2.md#title-with-emojis), and
+[Good Heading](page2.md#good-heading).
 
 ## Image Link absolute/relative
 

--- a/tests/integration/docs/nested/page2.md
+++ b/tests/integration/docs/nested/page2.md
@@ -1,3 +1,5 @@
 # Second Nested Test Page
 
 ## :smile_cat: Title with Emojis :material-star: :octicons-apps-16:
+
+## Good Heading

--- a/tests/integration/mkdocs.yml
+++ b/tests/integration/mkdocs.yml
@@ -14,6 +14,8 @@ plugins:
             '#acknowledge',
             '../index.html#BAD_ANCHOR',
             'page2.html#BAD_ANCHOR',
+           '../../#BAD_ANCHOR',  # if use_directory_urls=True
+            '../page2/#BAD_ANCHOR',  # if use_directory_urls=True
             '../../../tests',
           ]
         skip_downloads: True

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -338,6 +338,9 @@ def test_get_url_status__non_markdown_page(plugin):
         Mock(spec=File, src_path='drawing.svg', dest_path='drawing.svg',
              dest_uri='index.html', url='drawing.svg', src_uri='drawing.svg',
              page=None),
+        Mock(spec=File, src_path='page.html', dest_path='page.html',
+             dest_uri='page.html', url='page.html', src_uri='page.html',
+             page=None),
     ])
     files = {}
     files.update({os.path.normpath(file.url): file for file in mock_files})
@@ -346,6 +349,9 @@ def test_get_url_status__non_markdown_page(plugin):
     assert plugin.get_url_status('drawing.svg', 'index.md', set(), files) == 0
     assert plugin.get_url_status('/drawing.svg', 'index.md', set(), files) == 0
     assert plugin.get_url_status('not-existing.svg', 'index.md', set(), files) == 404
+
+    assert plugin.get_url_status('page.html', 'index.md', set(), files) == 0
+    assert plugin.get_url_status('page.html#heading', 'index.md', set(), files) == 0  # no validation for non-markdown pages
 
 
 def test_get_url_status__local_page_nested(plugin):


### PR DESCRIPTION
The current logic behind validation of links to local Markdown-based pages is broken when `use_directory_url: True`.

This was improved in #75 but there are still issues with it. No unit tests were added specifically for `use_directory_url: True`, and the integration tests obscure that the expected 404 links (`#BAD_ANCHOR`) aren't actually found at all when this option is enabled. This can be observed by removing the links from `tests/integration/mkdocs.yml`
```yaml
         raise_error_excludes:
           404: [
             'https://www.mkdocs.org/user-guide/*',
             '#acknowledge',
-            '../index.html#BAD_ANCHOR',
-            'page2.html#BAD_ANCHOR',
             '../../../tests',
           ]
```
and running the test `mkdocs build --use-directory-urls`. This should fail, but actually passes without any errors.

(In fact, this integration test in its current form should fail without any change - the URLs which should be added to `raise_error_excludes` for `use_directory_url: True` are `../page2/#BAD_ANCHOR` and `../../#BAD_ANCHOR`.)

---
This PR adds unit tests to ensure the expected behaviour for `get_url_status` is achieved for `use_directory_url: True` - which currently fail on `main` - and then reworks the implementation to support this. The primary logic change is to consider the type of the source file when trying to determine whether the anchor is valid. Rather than checking that the target page ends in `.html`, it now checks that the source file is a Markdown file (ends in `.md`). If it is Markdown, only then does it check that the expected anchor exists. In all other cases, it skips validating the anchor entirely.

(Conceptually it should be possible to support validating links to anchors in other types of documents, but this functionality isn't something that was previously possible either, so I haven't implemented it.)

---

The issues with the current logic can be demonstrated by checking out `994830b` - this commit is before the logic change added in this PR - and running unit and integration tests there.  The unit tests fail, and the integration tests don't detect the issue.