### PR TITLE
Add support for ignoring every URL on a page

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,23 @@ plugins:
       warn_on_ignored_urls: true
 ```
 
+### `ignore_pages`
+
+Avoid validating the URLs on the given list of markdown pages by ignoring them altogether.
+Each page in the list supports unix style wildcards `*`, `[]`, `?`, etc.
+
+Unlike `raise_error_excludes`, ignored URLs will not be fetched at all.
+
+```yaml
+plugins:
+  - search
+  - htmlproofer:
+      raise_error: True
+      ignore_pages:
+        - https://github.com/myprivateorg/*
+        - https://app.dynamic-service-of-some-kind.io*
+```
+
 ### `validate_external_urls`
 
 Avoids validating any external URLs (i.e those starting with http:// or https://).

--- a/README.md
+++ b/README.md
@@ -124,16 +124,14 @@ plugins:
 Avoid validating the URLs on the given list of markdown pages by ignoring them altogether.
 Each page in the list supports unix style wildcards `*`, `[]`, `?`, etc.
 
-Unlike `raise_error_excludes`, ignored URLs will not be fetched at all.
-
 ```yaml
 plugins:
   - search
   - htmlproofer:
       raise_error: True
       ignore_pages:
-        - https://github.com/myprivateorg/*
-        - https://app.dynamic-service-of-some-kind.io*
+        - path/to/file
+        - path/to/folder/*
 ```
 
 ### `validate_external_urls`

--- a/htmlproofer/plugin.py
+++ b/htmlproofer/plugin.py
@@ -70,6 +70,7 @@ class HtmlProoferPlugin(BasePlugin):
         ('validate_rendered_template', config_options.Type(bool, default=False)),
         ('ignore_urls', config_options.Type(list, default=[])),
         ('warn_on_ignored_urls', config_options.Type(bool, default=False)),
+        ('ignore_pages', config_options.Type(list, default=[])),
     )
 
     def __init__(self):
@@ -121,6 +122,12 @@ class HtmlProoferPlugin(BasePlugin):
 
         for url in urls:
             if any(fnmatch.fnmatch(url, ignore_url) for ignore_url in self.config['ignore_urls']):
+                if self.config['warn_on_ignored_urls']:
+                    log_warning(f"ignoring URL {url} from {page.file.src_path}")
+            elif any(
+                fnmatch.fnmatch(page.file.src_path, ignore_page)
+                for ignore_page in self.config['ignore_pages']
+            ):
                 if self.config['warn_on_ignored_urls']:
                     log_warning(f"ignoring URL {url} from {page.file.src_path}")
             else:


### PR DESCRIPTION
We save our outdated pages in an archive folder.
These pages shouldn't be checked for broken links.
And to make this possible I adapted the script to avoid validating the URLs on the given list of markdown pages in a similar way as ignore_urls.

The option is
```
ignore_pages:
  - path/to/file
  - path/to/folder/*
```

It checks for every link if it is on a page that should be ignored.
Maybe it's possible that it checks the page before going through every URL on that page.

